### PR TITLE
Change default logger to std_error

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -77,15 +77,19 @@ main(Args) ->
                     true -> SuggestedLogLevel;
                     _ -> notice
                end,
-    logger:set_handler_config(default, formatter, {logger_formatter,
-                                                      #{legacy_header => false,
-                                                        single_line => true,
-                                                        template => ?FORMAT_TEMPLATE}}),
+    logger:remove_handler(default),
+    logger:add_handler(cuttlefish, logger_std_h,
+                       #{config => #{type =>standard_error},
+                         formatter => {logger_formatter,
+                                        #{legacy_header => false,
+                                          single_line => true,
+                                          template => ?FORMAT_TEMPLATE}},
+                         filter_default => log,
+                         filters => [],
+                         level => all
+                        }),
 
-    logger:notice("set logger level to: ~p~n", [LogLevel]),
     logger:set_primary_config(level, LogLevel),
-    logger:set_handler_config(default, level, LogLevel),
-
     case Command of
         help ->
             print_help();


### PR DESCRIPTION
The default logger handler will print the logs to standard-io, and thus the log messages will be regarded as output of the `cuttlefish` command (escript).But they shoud not.

In this commit, I removed the default logger handler and then added a standard-error logger handler.