### PR TITLE
Add placeholder support

### DIFF
--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -27,7 +27,7 @@ config <- line* %{
 
 %% Lines are actual settings, comments, or horizontal whitespace,
 %% terminated by an end-of-line or end-of-file.
-line <- ((setting / comment / ws+) (crlf / eof)) / crlf %{
+line <- ((setting / comment / ws+ / placeholder) (crlf / eof)) / crlf %{
     case Node of
         [ Line, _EOL ] -> Line;
         Line -> Line
@@ -60,6 +60,9 @@ value <- (!(ws* crlf) .)+ %{
 %% A comment is any line that begins with a # sign, leading whitespace
 %% allowed.
 comment <- ws* "#" (!crlf .)* `comment`;
+
+%% A placeholder is any line that is surrounded with {{}}
+placeholder <- ws* "{{" (!crlf !"}}" .)+ "}}" `placeholder`;
 
 %% A word is one or more of letters, numbers and dashes or
 %% underscores.
@@ -133,6 +136,7 @@ ws <- [ \t] `ws`;
 %% @doc Only let through lines that are not comments or whitespace.
 is_setting(ws) -> false;
 is_setting(comment) -> false;
+is_setting(placeholder) -> false;
 is_setting(_) -> true.
 
 %% @doc Removes escaped dots from keys


### PR DESCRIPTION
I added a placeholder in emqx.conf for additional config entries, which will be replaced by the variables in the vars.config:

```
{{ additional_configs}}
```

But when we run the test-cases, the `conf_parse:file/1` will fail as this placeholder will not be replaced. 

This fix updates the conf_parse so that it ignores the placeholders, just like comments.
