### PR TITLE
Fix badarg error if the arity of translation fun is greater than 3

### DIFF
--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -231,10 +231,8 @@ prepare_translation_fun(Conf, Schema, Mapping, Xlat) ->
                 lists:any(fun(I) -> cuttlefish_variable:is_fuzzy_match(Key, I) end, Mappings0)
             end, Conf),
             {Xlat, [Conf1, Schema, Conf]};
-        OtherArity ->
-            {fun(_) ->
-                     {error, {translation_arity, {Mapping, OtherArity}}}
-             end, error}
+        _OtherArity ->
+            {fun() -> cuttlefish:invalid("translation fun can only have 1-3 arties") end, []}
     end.
 
 try_apply_translation(Mapping, XlatFun, XlatArgs) ->


### PR DESCRIPTION
The second argument of `erlang:apply/2` requires `[term()]`, but it was `error`.

https://github.com/emqx/cuttlefish/blob/0fe0d370dc618ff6aba79f3eb7b7156ee8135332/src/cuttlefish_generator.erl#L240-L246

Maybe related with https://github.com/emqx/emqx/issues/2590