### PR TITLE
chore(rebar.config): tag cuttlefish

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {escript_incl_apps, [getopt, hocon]}.
 
 {deps, [ {getopt, {git, "https://github.com/emqx/getopt.git", {tag, "v1.0.2"}}}
-       , {hocon, {git, "https://github.com/emqx/hocon.git", {branch, "master"}}}]}.
+       , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.1.0"}}}]}.
 
 {profiles,
     [{test, [{deps, [bbmustache]}]},


### PR DESCRIPTION
will tag `0.0.1-hocon` to hocon branch of this repo