### PR TITLE
chore: use rebar3 in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,10 @@ DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto in
 	public_key mnesia syntax_tools compiler
 COMBO_PLT = $(HOME)/.cuttlefish_combo_dialyzer_plt
 
-REBAR := $(CURDIR)/rebar3
+REBAR := $(shell which rebar3)
 
 .PHONY: all
 all: $(REBAR) compile
-
-$(REBAR):
-	@curl -k -f -L "https://github.com/emqx/rebar3/releases/download/3.14.3-emqx-6/rebar3" -o ./rebar3
-	@chmod +x ./rebar3
 
 .PHONY: deps
 deps: $(REBAR)


### PR DESCRIPTION
Reason:

* The old rebar3 does not run on OTP 25.
* The new rebar3 is built on OTP 25 which does not work on older OTP.

To make it simple, use the rebar3 in path.